### PR TITLE
Fix _parse_response of “get capabilities quota”

### DIFF
--- a/ovhai/api/capabilities/get_v1_capabilities_quota.py
+++ b/ovhai/api/capabilities/get_v1_capabilities_quota.py
@@ -24,6 +24,8 @@ def _parse_response(
     if response.status_code == HTTPStatus.OK:
         response_200 = []
         _response_200 = response.json()
+        if not isinstance(_response_200, list):
+            _response_200 = [_response_200]
         for response_200_item_data in _response_200:
             response_200_item = ProjectQuotas.from_dict(response_200_item_data)
 


### PR DESCRIPTION
It seems that when there’s only one element to return, it’s directly the `dict` and not a list of one `dict` (as expected by the current code).