### PR TITLE
Fix _gpu_information unset detection in Flavor

### DIFF
--- a/ovhai/models/flavor.py
+++ b/ovhai/models/flavor.py
@@ -86,7 +86,7 @@ class Flavor:
 
         _gpu_information = d.pop("gpuInformation", UNSET)
         gpu_information: Union[Unset, GpuInformation]
-        if isinstance(_gpu_information, Unset):
+        if isinstance(_gpu_information, Unset) or _gpu_information is None:
             gpu_information = UNSET
         else:
             gpu_information = GpuInformation.from_dict(_gpu_information)


### PR DESCRIPTION
It seems that the `_gpu_information` exists and is `None` even if no _gpu_information is available (breaking the `UNSET` detection). 